### PR TITLE
set fbjs as peer dependency and fix import statements

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -14,8 +14,8 @@ import ReactNative, {
 } from 'react-native';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import deprecatedPropType from 'react-native/Libraries/Utilities/deprecatedPropType';
-import invariant from 'react-native/node_modules/fbjs/lib/invariant';
-import keyMirror from 'react-native/node_modules/fbjs/lib/keyMirror';
+import invariant from 'fbjs/lib/invariant';
+import keyMirror from 'fbjs/lib/keyMirror';
 var WKWebViewManager = NativeModules.WKWebViewManager;
 
 var BGWASH = 'rgba(255,255,255,0.8)';

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "pre-push#master": [
     "lint"
   ],
+  "dependencies": {
+    "fbjs": "0.8.3"
+  },
   "peerDependencies": {
     "react-native": "*"
   }


### PR DESCRIPTION
This pr changes the imports and adds fjbs now as a dependency.
This also doesn't include other changes. however I did leave fbjs as a versioned dependency