### PR TITLE
Support window.open

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -11,7 +11,7 @@
 #import "RCTView.h"
 #import "UIView+React.h"
 
-@interface RCTWKWebView () <WKNavigationDelegate, RCTAutoInsetsProtocol>
+@interface RCTWKWebView () <WKNavigationDelegate, WKUIDelegate, RCTAutoInsetsProtocol>
 
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingStart;
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingFinish;
@@ -35,6 +35,7 @@
     _contentInset = UIEdgeInsetsZero;
     _webView = [[WKWebView alloc] initWithFrame:self.bounds];
     _webView.navigationDelegate = self;
+    _webView.UIDelegate = self;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionNew context:nil];
     [self addSubview:_webView];
   }
@@ -250,5 +251,19 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     _onLoadingFinish([self baseEvent]);
   }
 }
+
+#pragma mark - WKUIDelegate methods
+
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+  // In order to support window.open
+  if (!navigationAction.targetFrame.isMainFrame) {
+    UIApplication *app = [UIApplication sharedApplication];
+    [app openURL:navigationAction.request.URL];
+  }
+
+  return nil;
+}
+
 
 @end

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -258,8 +258,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   // In order to support window.open
   if (!navigationAction.targetFrame.isMainFrame) {
+    NSURL* url = navigationAction.request.URL;
     UIApplication *app = [UIApplication sharedApplication];
-    [app openURL:navigationAction.request.URL];
+
+    if ([app canOpenURL:url]) {
+      [app openURL:url];
+    }
   }
 
   return nil;


### PR DESCRIPTION
URLs opened with `window.open` will open in Safari (or the appropriate app for that URL).

In the future, I'd like to have this customizable through a `prop`, so we can choose whether to open in Safari, a SafariView modal, etc.
