### PR TITLE
Props re-arranged to prevent loadRequest firing until all props ready.

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -250,7 +250,6 @@ var WKWebView = React.createClass({
         ref={RCT_WEBVIEW_REF}
         key="webViewKey"
         style={webViewStyles}
-        source={resolveAssetSource(source)}
         injectedJavaScript={this.props.injectedJavaScript}
         bounces={this.props.bounces}
         scrollEnabled={this.props.scrollEnabled}
@@ -262,6 +261,7 @@ var WKWebView = React.createClass({
         onLoadingError={this._onLoadingError}
         onProgress={this._onProgress}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        source={resolveAssetSource(source)}
       />;
 
     return (


### PR DESCRIPTION
In iOS 10, `setSource` was getting called before other props (like `sendCookies`).  In our case, the bug was that cookies weren't getting set.