### PR TITLE
Allow react-native-wkwebview to be imported on windows.

### DIFF
--- a/WKWebView.windows.js
+++ b/WKWebView.windows.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};


### PR DESCRIPTION
Required change to work on React Native Windows.