### PR TITLE
Added customUserAgent property

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ It allows you to provide a fallback URL for iOS 8 users.
 <WKWebView source={{ file: RNFS.MainBundlePath + '/data/index.html', allowingReadAccessToURL: RNFS.MainBundlePath }} />
 ```
 
+- customUserAgent
+
+Set the user agent string to a be something other that the default, in the same way you can set `customUserAgent` on `WKWebView`. For example to pretend to be Google Chrome on OSX...
+
+```
+<WKWebView customUserAgent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.67 Safari/537.36' />
+```
+
 **From WKWebview -> React Native (New in 0.3.0)**
 
 - onMessage
@@ -91,7 +99,7 @@ Then in your webview, you can post message to React Native using
 window.webkit.messageHandlers.reactNative.postMessage({data: 'hello!'});
 ```
 
-Then your React Native should have 
+Then your React Native should have
 
 ```
 {name: 'reactNative', body: {data: 'hello!'}}
@@ -105,7 +113,7 @@ So I recommend to keep your data simple and JSON-friendly.
 
 **From React Native -> WkWebView (New in 0.3.0)**
 
-There is a `evaluateJavaScript` method on WKWebView, which does exactly what its name suggests. To send message from React Native to WebView, 
+There is a `evaluateJavaScript` method on WKWebView, which does exactly what its name suggests. To send message from React Native to WebView,
 you can define a callback method on your WebView:
 
 ```

--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -198,6 +198,11 @@ var WKWebView = React.createClass({
      * of new window. Default is false to be backward compatible.
      */
     openNewWindowInWebView: PropTypes.bool,
+
+    /**
+    * Sets the customized user agent by using of the WKWebView
+    */
+    customUserAgent: PropTypes.string
   },
   getInitialState() {
     return {
@@ -275,6 +280,7 @@ var WKWebView = React.createClass({
         onProgress={this._onProgress}
         onMessage={this._onMessage}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        customUserAgent={this.props.customUserAgent}
       />;
 
     return (

--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -42,6 +42,7 @@ RCT_EXPORT_VIEW_PROPERTY(onLoadingError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
+RCT_REMAP_VIEW_PROPERTY(customUserAgent, _webView.customUserAgent, NSString)
 
 RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)
 {


### PR DESCRIPTION
Hi,

This PR exposes the `customUserAgent` property available in `WKWebView`. Alongside this there is also a fringe case to take into consideration. If you create...

```js
<WKWebView
  source={{uri: 'http://github.com'}}
  customUserAgent='My User Agent' />
```

...when the props get set in iOS you have no way of guaranteeing the order they will be set. If the `source` is set before the `customUserAgent` then the first request out of the webview will have the default user agent. Fine for some use-cases but not ideal.

To cope with this, I set the source into the`RCTWKWebView` and mark it as being dirty. Then when `didSetProps` is executed I check if the source was set and if it is dirty. It's at this point I go ahead and tell the`WKWebView` to start loading. This should ensure that when first instantiating, all the props are set correctly before the `WKWebView` starts hitting the outside world.

The other solutions I thought about were having an `initialUserAgent` in the `source` dictionary but this seemed disjoint as you'd have to set it twice. The other one was to just wait a moment before executing the source but this seems brittle and delays loading for no reason. The solution I've put together seems to just-work from a usage perspective only with the slightly deferred load.