### PR TITLE
Add a removeData function

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -344,6 +344,10 @@ var WKWebView = React.createClass({
     return WKWebViewManager.evaluateJavaScript(this.getWebViewHandle(), js);
   },
 
+  removeData: function(types) {
+    return WKWebViewManager.removeData(this.getWebViewHandle(), types)
+  },
+
   /**
    * We return an event with a bunch of fields including:
    *  url, title, loading, canGoBack, canGoForward
@@ -446,3 +450,15 @@ var styles = StyleSheet.create({
 });
 
 export default WKWebView;
+
+const WebsiteDataTypes = {
+  DiskCache: 'WKWebsiteDataTypeDiskCache',
+  OfflineWebApplicationCache: 'WKWebsiteDataTypeOfflineWebApplicationCache',
+  MemoryCache: 'WKWebsiteDataTypeMemoryCache',
+  LocalStorage: 'WKWebsiteDataTypeLocalStorage',
+  Cookies: 'WKWebsiteDataTypeCookies',
+  SessionStorage: 'WKWebsiteDataTypeSessionStorage',
+  IndexedDBDatabases: 'WKWebsiteDataTypeIndexedDBDatabases',
+  WebSQLDatabases: 'WKWebsiteDataTypeWebSQLDatabases',
+}
+export { WebsiteDataTypes }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
-import WKWebView from './WKWebView';
+import WKWebView, {WebsiteDataTypes} from './WKWebView';
 
 export default WKWebView;
+export { WebsiteDataTypes }

--- a/ios/RCTWKWebView/RCTWKWebView.h
+++ b/ios/RCTWKWebView/RCTWKWebView.h
@@ -13,26 +13,27 @@ extern NSString *const RCTJSNavigationScheme;
 @protocol RCTWKWebViewDelegate <NSObject>
 
 - (BOOL)webView:(RCTWKWebView *)webView
-shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
-   withCallback:(RCTDirectEventBlock)callback;
+    shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
+                 withCallback:(RCTDirectEventBlock)callback;
 
 @end
 
 @interface RCTWKWebView : RCTView
 
-@property (nonatomic, weak) id<RCTWKWebViewDelegate> delegate;
+@property(nonatomic, weak) id<RCTWKWebViewDelegate> delegate;
 
-@property (nonatomic, copy) NSDictionary *source;
-@property (nonatomic, assign) UIEdgeInsets contentInset;
-@property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
-@property (nonatomic, assign) BOOL openNewWindowInWebView;
-@property (nonatomic, copy) NSString *injectedJavaScript;
-
+@property(nonatomic, copy) NSDictionary *source;
+@property(nonatomic, assign) UIEdgeInsets contentInset;
+@property(nonatomic, assign) BOOL automaticallyAdjustContentInsets;
+@property(nonatomic, assign) BOOL openNewWindowInWebView;
+@property(nonatomic, copy) NSString *injectedJavaScript;
 
 - (void)goForward;
 - (void)goBack;
 - (void)reload;
 - (void)stopLoading;
-- (void)evaluateJavaScript:(NSString *)javaScriptString completionHandler:(void (^)(id, NSError *error))completionHandler;
-
+- (void)evaluateJavaScript:(NSString *)javaScriptString
+         completionHandler:(void (^)(id, NSError *error))completionHandler;
+-(void)removeData:(NSArray *)types
+         completionHandler:(void (^)(id, NSError *error))completionHandler;
 @end

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -85,6 +85,23 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_webView evaluateJavaScript:javaScriptString completionHandler:completionHandler];
 }
 
+- (void)removeData:(NSArray *)types
+         completionHandler:(void (^)(id, NSError *error))completionHandler
+{
+  NSSet *websiteDataTypes;
+  
+  if (types != nil) {
+    websiteDataTypes = [NSSet setWithArray:types];
+  } else {
+    websiteDataTypes = [WKWebsiteDataStore allWebsiteDataTypes];
+  }
+
+  NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
+  [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes modifiedSince:dateFrom completionHandler:^{
+    completionHandler(self, nil);
+  }];
+}
+
 - (void)goBack
 {
   [_webView goBack];

--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -112,6 +112,28 @@ RCT_EXPORT_METHOD(evaluateJavaScript:(nonnull NSNumber *)reactTag
   }];
 }
 
+RCT_EXPORT_METHOD(removeData:(nonnull NSNumber *)reactTag
+                  types:(NSArray *)types
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWKWebView *> *viewRegistry) {
+    RCTWKWebView *view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[RCTWKWebView class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting RCTWKWebView, got: %@", view);
+    } else {
+      [view removeData:types completionHandler:^(id result, NSError *error) {
+        if (error) {
+          reject(@"removeFailed", @"Error calling removeData", error);
+        } else {
+          resolve(nil);
+        }
+      }];
+    }
+  }];
+  
+}
+
 #pragma mark - Exported synchronous methods
 
 - (BOOL)webView:(__unused RCTWKWebView *)webView


### PR DESCRIPTION
This function will clear the specified data from the WKWebView. You
call the function with an array of the types you want to remove:

this.webView.removeData([
  WebsiteDataTypes.DiskCache,
  WebsiteDataTypes.OfflineWebApplicationCache,
  WebsiteDataTypes.MemoryCache,
  WebsiteDataTypes.LocalStorage,
  WebsiteDataTypes.Cookies,
  WebsiteDataTypes.SessionStorage,
  WebsiteDataTypes.IndexedDBDatabases,
  WebsiteDataTypes.WebSQLDatabases,
])

WebsiteDataTypes is now exported from the module, so you include:

import WKWebView, { WebsiteDataTypes } from 'react-native-wkwebview-reborn'

If you pass null for the array then all data types are removed.