### PR TITLE
Use shared process pool to share cookies between instances

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.h
+++ b/ios/RCTWKWebView/RCTWKWebView.h
@@ -1,3 +1,5 @@
+#import <WebKit/WebKit.h>
+
 #import <React/RCTView.h>
 
 @class RCTWKWebView;
@@ -19,6 +21,8 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @end
 
 @interface RCTWKWebView : RCTView
+
+- (instancetype)initWithProcessPool:(WKProcessPool *)processPool;
 
 @property (nonatomic, weak) id<RCTWKWebViewDelegate> delegate;
 

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -2,7 +2,6 @@
 
 #import "WeakScriptMessageDelegate.h"
 
-#import <WebKit/WebKit.h>
 #import <UIKit/UIKit.h>
 
 #import <React/RCTAutoInsetsProtocol.h>
@@ -33,13 +32,22 @@
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-  if ((self = [super initWithFrame:frame])) {
+  return self = [super initWithFrame:frame];
+}
+
+RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
+
+- (instancetype)initWithProcessPool:(WKProcessPool *)processPool
+{
+  if(self = [self initWithFrame:CGRectZero])
+  {
     super.backgroundColor = [UIColor clearColor];
     
     _automaticallyAdjustContentInsets = YES;
     _contentInset = UIEdgeInsetsZero;
     
     WKWebViewConfiguration* config = [[WKWebViewConfiguration alloc] init];
+    config.processPool = processPool;
     WKUserContentController* userController = [[WKUserContentController alloc]init];
     [userController addScriptMessageHandler:[[WeakScriptMessageDelegate alloc] initWithDelegate:self] name:@"reactNative"];
     config.userContentController = userController;
@@ -52,8 +60,6 @@
   }
   return self;
 }
-
-RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)loadRequest:(NSURLRequest *)request
 {

--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -16,13 +16,24 @@
 {
   NSConditionLock *_shouldStartLoadLock;
   BOOL _shouldStartLoad;
+  WKProcessPool *_processPool;
+}
+
+- (id)init {
+  self = [super init];
+  
+  if (self) {
+    _processPool = [[WKProcessPool alloc] init];
+  }
+  
+  return self;
 }
 
 RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-  RCTWKWebView *webView = [RCTWKWebView new];
+  RCTWKWebView *webView = [[RCTWKWebView alloc] initWithProcessPool:_processPool];
   webView.delegate = self;
   return webView;
 }


### PR DESCRIPTION
Fixes #63 

Using the same process pool for different instances is the recommended way to share cookies between instances and replicates the behavior from the react-native WebView.