### PR TITLE
Crash on iOS 11 during RCTWKWebViewManager destruction

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -19,12 +19,6 @@
   BOOL _shouldStartLoad;
 }
 
-- (id)init {
-  self = [super init];
-
-  return self;
-}
-
 RCT_EXPORT_MODULE()
 
 - (UIView *)view

--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -17,16 +17,11 @@
 {
   NSConditionLock *_shouldStartLoadLock;
   BOOL _shouldStartLoad;
-  WKProcessPool *_processPool;
 }
 
 - (id)init {
   self = [super init];
-  
-  if (self) {
-    _processPool = [[WKProcessPool alloc] init];
-  }
-  
+
   return self;
 }
 
@@ -34,7 +29,7 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-  RCTWKWebView *webView = [[RCTWKWebView alloc] initWithProcessPool:_processPool];
+  RCTWKWebView *webView = [[RCTWKWebView alloc] initWithProcessPool:[[WKProcessPool alloc] init]];
   webView.delegate = self;
   return webView;
 }


### PR DESCRIPTION
I basically let RCTWKWebViewManager stop holding a reference to WKProcessPool. Just left the pool bound to the WKWebView.