### PR TITLE
Bug fixed - white safe-area on the top of viewport when built by XCode9

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -68,6 +68,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration:config];
     _webView.UIDelegate = self;
     _webView.navigationDelegate = self;
+    if (@available(iOS 11.0, *)) {
+      [_webView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    }
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionNew context:nil];
     [self addSubview:_webView];
   }


### PR DESCRIPTION
By default, the wkwebivew will have a white statusbar inset on the top of your webview. Even if you have set the viewport by yourself, like viewport-fit=cover. It will still, have white space inset on the bottom. This PR is going to fix this issue.