### PR TITLE
Support React 16

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import React, {
-  PropTypes
-} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import ReactNative, {
   requireNativeComponent,
   EdgeInsetsPropType,
@@ -73,7 +73,7 @@ var defaultRenderError = (errorDomain, errorCode, errorDesc) => (
  * Renders a native WebView.
  */
 
-var WKWebView = React.createClass({
+var WKWebView = createReactClass({
   statics: {
     JSNavigationScheme: JSNavigationScheme,
     NavigationType: NavigationType,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "url": "https://github.com/CRAlpha/react-native-wkwebview/issues"
   },
   "dependencies": {
-    "fbjs": "^0.8.3"
+    "create-react-class": "^15.6.2",
+    "fbjs": "^0.8.3",
+    "prop-types": "^15.6.0"
   },
   "description": "React Native WKWebView for iOS",
   "devDependencies": {},


### PR DESCRIPTION
If you update your react version to 16.0.0 this package does not work.

This PR adds necessary dependencies to support `PropTypes` and `React.createClass`.