### PR TITLE
Ability to take screenshot of the view

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -369,6 +369,16 @@ var WKWebView = React.createClass({
     )
   },
 
+  /**
+  * Take a screenshot of the webview
+  */
+  screenshot: function(options) {
+    return WKWebViewManager.screenshot(this.getWebViewHandle(), options || {});
+  },
+
+  /**
+   * Evaluate javascript
+   */
   evaluateJavaScript: function(js) {
     return WKWebViewManager.evaluateJavaScript(this.getWebViewHandle(), js);
   },


### PR DESCRIPTION
This PR adds a method that can be called to get a screenshot of the WKWebView.

Other methods don't work (I tried wrapping with `react-native-view-shot` and `react-native-view-snapshot`).

TODO: Add ability to configure the capture (PNG/JPG/Compression/size output).