### PR TITLE
Add callback for response mime

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -188,6 +188,11 @@ var WKWebView = React.createClass({
      * @platform ios
      */
     onShouldStartLoadWithRequest: PropTypes.func,
+      /**
+     * Allows custom handling of response with MIME type
+     * @platform ios
+     */
+    onDidLoadWithResponse: PropTypes.func,
     /**
      * Copies cookies from sharedHTTPCookieStorage when calling loadRequest.
      * Set this to true to emulate behavior of WebView component.
@@ -266,6 +271,18 @@ var WKWebView = React.createClass({
       WKWebViewManager.startLoadWithResult(!!shouldStart, event.nativeEvent.lockIdentifier);
     });
 
+    var onDidLoadWithResponse =
+    this.props.onDidLoadWithResponse &&
+    ((event: Event) => {
+      var didLoad =
+        this.props.onDidLoadWithResponse &&
+        this.props.onDidLoadWithResponse(event.nativeEvent);
+      WKWebViewManager.didLoadWithResult(
+        !!didLoad,
+        event.nativeEvent.lockIdentifier
+      );
+    });
+
     if (this.props.source && typeof this.props.source == 'object') {
       var source = Object.assign({}, this.props.source, { 
         sendCookies: this.props.sendCookies,
@@ -299,6 +316,7 @@ var WKWebView = React.createClass({
         onProgress={this._onProgress}
         onMessage={this._onMessage}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        onDidLoadWithResponse={onDidLoadWithResponse}
         pagingEnabled={this.props.pagingEnabled}
         directionalLockEnabled={this.props.directionalLockEnabled}
       />;

--- a/ios/RCTWKWebView/RCTWKWebView.h
+++ b/ios/RCTWKWebView/RCTWKWebView.h
@@ -18,6 +18,10 @@ extern NSString *const RCTJSNavigationScheme;
 shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
    withCallback:(RCTDirectEventBlock)callback;
 
+- (BOOL)webView:(RCTWKWebView *)webView
+didLoadWithResponse:(NSMutableDictionary<NSString *, id> *)response
+   withCallback:(RCTDirectEventBlock)callback;
+
 @end
 
 @interface RCTWKWebView : RCTView

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -31,6 +31,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingFinish;
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingError;
 @property (nonatomic, copy) RCTDirectEventBlock onShouldStartLoadWithRequest;
+@property (nonatomic, copy) RCTDirectEventBlock onDidLoadWithResponse;
 @property (nonatomic, copy) RCTDirectEventBlock onProgress;
 @property (nonatomic, copy) RCTDirectEventBlock onMessage;
 @property (assign) BOOL sendCookies;
@@ -287,6 +288,18 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 }
 
 #pragma mark - WKNavigationDelegate methods
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler {
+  
+  NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+  [event addEntriesFromDictionary: @{
+                                     @"mimeType": navigationResponse.response.MIMEType,
+                                     }];
+  
+  [self.delegate webView:self didLoadWithResponse:event withCallback:_onDidLoadWithResponse];
+  
+  decisionHandler(WKNavigationResponsePolicyAllow);
+}
 
 - (void)webView:(__unused WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {

--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -15,8 +15,10 @@
 
 @implementation RCTWKWebViewManager
 {
-  NSConditionLock *_shouldStartLoadLock;
-  BOOL _shouldStartLoad;
+    NSConditionLock *_shouldStartLoadLock;
+    NSConditionLock *_didLoadLock;
+    BOOL _shouldStartLoad;
+    BOOL _didLoad;
 }
 
 RCT_EXPORT_MODULE()
@@ -42,6 +44,7 @@ RCT_EXPORT_VIEW_PROPERTY(onLoadingStart, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLoadingFinish, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLoadingError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDidLoadWithResponse, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(hideKeyboardAccessoryView, BOOL)
@@ -141,7 +144,7 @@ RCT_EXPORT_METHOD(evaluateJavaScript:(nonnull NSNumber *)reactTag
 
 - (BOOL)webView:(__unused RCTWKWebView *)webView
 shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
-   withCallback:(RCTDirectEventBlock)callback
+   withCallback:(RCTDirectEventBlock)callback;
 {
   _shouldStartLoadLock = [[NSConditionLock alloc] initWithCondition:arc4random()];
   _shouldStartLoad = YES;
@@ -170,5 +173,38 @@ RCT_EXPORT_METHOD(startLoadWithResult:(BOOL)result lockIdentifier:(NSInteger)loc
                "got %zd, expected %zd", lockIdentifier, _shouldStartLoadLock.condition);
   }
 }
+
+- (BOOL)webView:(__unused RCTWKWebView *)webView
+didLoadWithResponse:(NSMutableDictionary<NSString *, id> *)response
+   withCallback:(RCTDirectEventBlock)callback;
+{
+    _didLoadLock = [[NSConditionLock alloc] initWithCondition:arc4random()];
+    _didLoad = YES;
+    response[@"lockIdentifier"] = @(_didLoadLock.condition);
+    callback(response);
+    
+    // Block the main thread for a maximum of 250ms until the JS thread returns
+    if ([_didLoadLock lockWhenCondition:0 beforeDate:[NSDate dateWithTimeIntervalSinceNow:.25]]) {
+        BOOL returnValue = _didLoad;
+        [_didLoadLock unlock];
+        _didLoadLock = nil;
+        return returnValue;
+    } else {
+        RCTLogWarn(@"Did not receive response to didLoad in time, defaulting to YES");
+        return YES;
+    }
+}
+
+RCT_EXPORT_METHOD(didLoadWithResult:(BOOL)result lockIdentifier:(NSInteger)lockIdentifier)
+{
+    if ([_didLoadLock tryLockWhenCondition:lockIdentifier]) {
+        _didLoad = result;
+        [_didLoadLock unlockWithCondition:0];
+    } else {
+        RCTLogWarn(@"didLoadWithResult invoked with invalid lockIdentifier: "
+                   "got %zd, expected %zd", lockIdentifier, _didLoadLock.condition);
+    }
+}
+
 
 @end


### PR DESCRIPTION
Implements `decidePolicyForNavigationResponse` delegate method to provide mime type of response once the page has loaded.