### PR TITLE
Improve scrollview

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -68,10 +68,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration:config];
     _webView.UIDelegate = self;
     _webView.navigationDelegate = self;
+    _webView.scrollView.delegate = self;
     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionNew context:nil];
     [self addSubview:_webView];
   }
   return self;
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+  if (!scrollView.scrollEnabled)
+    scrollView.bounds = _webView.bounds;
 }
 
 - (void)loadRequest:(NSURLRequest *)request

--- a/package.json
+++ b/package.json
@@ -77,5 +77,5 @@
   "scripts": {
     "lint": "eslint --ext .js --ext .jsx ."
   },
-  "version": "1.9.0"
+  "version": "1.10.0"
 }


### PR DESCRIPTION
This improvement makes scrollView inside of webView not slide up in order to make the input fields visible when the input fields is focused and keyboard appears.

This patch is inspired by this article:
https://stackoverflow.com/questions/15926260/set-uiwebview-content-not-to-move-when-keyboard-is-shown
