### PR TITLE
Fixed localStorage & cookie sharing between multiple WKWebViewInstances

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -29,14 +29,23 @@ RCT_ENUM_CONVERTER(UIScrollViewContentInsetAdjustmentBehavior, (@{
 @implementation RCTWKWebViewManager
 {
   NSConditionLock *_shouldStartLoadLock;
+  WKProcessPool *_processPool;
   BOOL _shouldStartLoad;
 }
 
 RCT_EXPORT_MODULE()
 
+- (id)init {
+  if (self = [super init]) {
+    _processPool = [[WKProcessPool alloc] init];
+  }
+    
+  return self;
+}
+
 - (UIView *)view
 {
-  RCTWKWebView *webView = [[RCTWKWebView alloc] initWithProcessPool:[[WKProcessPool alloc] init]];
+  RCTWKWebView *webView = [[RCTWKWebView alloc] initWithProcessPool:_processPool];
   webView.delegate = self;
   return webView;
 }


### PR DESCRIPTION
This fix came out of necessity with our own use of WKWebView for our service. This fix uses a shared pool across all WKWebView instances to allow for shared cookies & local storage at a domain specific level.