### PR TITLE
v prefix for git tag

### DIFF
--- a/react-native-wkwebview.podspec
+++ b/react-native-wkwebview.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com/CRAlpha/react-native-wkwebview.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/CRAlpha/react-native-wkwebview.git", :tag => "v#{s.version}" }
 
   s.source_files  = "ios/RCTWKWebView/*.{h,m}"
 


### PR DESCRIPTION
Issue: Unable to install the package with pods as get the following error:

```
[!] Error installing react-native-wkwebview
[!] /usr/local/bin/git clone https://github.com/CRAlpha/react-native-wkwebview.git /var/folders/8j/j34s4m750vg93j95c5npb8jw0001yg/T/d20180416-88775-3bwo2f --template= --single-branch --depth 1 --branch 1.17.0
```

Fix:
Add the "v" prefix to the tag template, as this is the naming convention that version tags contain.

![screen shot 2018-04-16 at 12 22 01 pm](https://user-images.githubusercontent.com/397226/38822247-d6ad5936-4170-11e8-8d19-63104331b40d.png)
