### PR TITLE
fix messagingEnabled cannot work bug

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -120,6 +120,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   }
 }
 
+- (void)setMessagingEnabled:(BOOL)messagingEnabled {
+  _messagingEnabled = messagingEnabled;
+  [self setupPostMessageScript];
+}
+
 - (void)resetupScripts {
   [_webView.configuration.userContentController removeAllUserScripts];
   [self setupPostMessageScript];


### PR DESCRIPTION
## Description
cannot receive message in `onMessage` method when sending message from html Web Page using `window.postMessage` method.

## Steps to Reproduce
in example project.		
1. remove prop `injectedJavaScript="window.postMessage('Hello from WkWebView');"`.		
2. change source url to [testURL](http://ov1cr6s9d.bkt.clouddn.com/testwebview.html).	
3. click `send Message to ReactNative` button in web page.