### PR TITLE
Fixing issue where postMessage handler would not be initialized properly

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -90,6 +90,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   return self;
 }
 
+- (void)setMessagingEnabled:(BOOL)messagingEnabled {
+  _messagingEnabled = messagingEnabled;
+  [self resetupScripts];
+}
+
 - (void)setInjectJavaScript:(NSString *)injectJavaScript {
   _injectJavaScript = injectJavaScript;
   self.atStartScript = [[WKUserScript alloc] initWithSource:injectJavaScript


### PR DESCRIPTION
I ran into this issue when using the new `injectJavaScript` prop.  The initialization of `injectJavaScript` was firing before `onMessage` was initialized, leading to `_messagingEnabled` being set to false when the setters fired.  Because of this, the `onMessage` bridge was never set up, even when `_messagingEnabled` is true.