### PR TITLE
Enable wk cookie store

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ If set to true, links with `target="_blank"` or `window.open` will be opened in 
 
 Set `sendCookies` to true to copy cookies from `sharedHTTPCookieStorage` when calling loadRequest.  This emulates the behavior of react-native's `WebView` component. You can set cookies using `react-native-cookies` Default is false.
 
+- **useWKCookieStore**
+
+Set `useWKCookieStore` to true to use the webView's `WKHTTPCookieStorage`. All Cookies from `sharedHTTPCookieStorage` will be copied to it.
+
 - **source={{file: '', allowingReadAccessToURL: '' }}**
 
 This allows WKWebView loads a local HTML file. Please note the underlying API is only introduced in iOS 9+. So in iOS 8, it will simple ignores these two properties.

--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -229,6 +229,10 @@ class WKWebView extends React.Component {
      */
     sendCookies: PropTypes.bool,
     /**
+     * Initializes the webView's WKHTTPCookieStorage and copies all cookies from sharedHTTPCookieStorage
+     */
+    useWKCookieStore: PropTypes.bool,
+    /**
      * If set to true, target="_blank" or window.open will be opened in WebView, instead
      * of new window. Default is false to be backward compatible.
      */
@@ -312,7 +316,8 @@ class WKWebView extends React.Component {
     if (this.props.source && typeof this.props.source == 'object') {
       source = Object.assign({}, this.props.source, {
         sendCookies: this.props.sendCookies,
-        customUserAgent: this.props.customUserAgent || this.props.userAgent
+        customUserAgent: this.props.customUserAgent || this.props.userAgent,
+        useWKCookieStore: this.props.useWKCookieStore
       });
     }
 

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -34,6 +34,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onMessage;
 @property (nonatomic, copy) RCTDirectEventBlock onScroll;
 @property (assign) BOOL sendCookies;
+@property (assign) BOOL useWKCookieStore;
 @property (nonatomic, strong) WKUserScript *atStartScript;
 @property (nonatomic, strong) WKUserScript *atEndScript;
 
@@ -317,13 +318,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 }
 
 - (void) copyCookies {
-  
+
   NSHTTPCookieStorage* storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
   NSArray* array = [storage cookies];
-  
-  
+
+
   if (@available(ios 11,*)) {
-    
+
     // The webView websiteDataStore only gets initialized, when needed. Setting cookies on the dataStore's
     // httpCookieStore doesn't seem to initialize it. That's why fetchDataRecordsOfTypes is called.
     // All the cookies of the sharedHttpCookieStorage, which is used in react-native-cookie,
@@ -340,10 +341,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     for (NSHTTPCookie* cookie in array){
       NSString* cookieSource = [NSString stringWithFormat:@"document.cookie = '%@'", [self cookieDescription:cookie]];
       WKUserScript* cookieScript = [[WKUserScript alloc]
-                                  initWithSource:cookieSource
-                                  injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO];
-      
-    
+                                    initWithSource:cookieSource
+                                    injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO];
+
+
       [_webView.configuration.userContentController addUserScript:cookieScript];
     }
   }
@@ -354,8 +355,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   if (![_source isEqualToDictionary:source]) {
     _source = [source copy];
     _sendCookies = [source[@"sendCookies"] boolValue];
+    _useWKCookieStore = [source[@"useWKCookieStore"] boolValue];
 
-    if (_sendCookies) {
+    if (_useWKCookieStore) {
       [self copyCookies];
     }
 

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -299,6 +299,23 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_webView stopLoading];
 }
 
+- (NSString *) cookieDescription:(NSHTTPCookie *)cookie {
+    
+    NSMutableString *cDesc = [[NSMutableString alloc] init];
+    [cDesc appendFormat:@"%@=%@;",
+     [[cookie name] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding],
+     [[cookie value] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    if ([cookie.domain length] > 0)
+        [cDesc appendFormat:@"domain=%@;", [cookie domain]];
+    if ([cookie.path length] > 0)
+        [cDesc appendFormat:@"path=%@;", [cookie path]];
+    if (cookie.expiresDate != nil)
+        [cDesc appendFormat:@"expiresDate=%@;", [cookie expiresDate]];
+    
+    
+    return cDesc;
+}
+
 - (void) copyCookies {
   
   NSHTTPCookieStorage* storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];


### PR DESCRIPTION
To improve the cookie handling a new option `useWKCookieStore` is introduced. 
When using `useWKCookieStore`, the cookies from `HTTPCookieStorage` get copied to the webView’s `WKHTTPCookieStorage`. 
The cookie Plugins [https://github.com/joeferraro/react-native-cookies/](https://github.com/joeferraro/react-native-cookies/) and [https://github.com/shimohq/react-native-cookie](https://github.com/shimohq/react-native-cookie) do not support `WKHTTPCookieStorage` at the moment and use `NSHTTPCookieStorage` to save the cookies.
That's why the cookies are copied from the `NSHTTPCookieStorage`.
A workaround is used to initialize the `WKHTTPCookieStorage` correctly. The WebKit bug https://bugs.webkit.org/show_bug.cgi?id=185483 prevents the initialization.