### PR TITLE
Allow source to be a required module

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ It allows you to provide a fallback URL for iOS 8 users.
 <WKWebView source={{ file: RNFS.MainBundlePath + '/data/index.html', allowingReadAccessToURL: RNFS.MainBundlePath }} />
 ```
 
+You can also use the `require` syntax (sendCookies and userAgent will be ignored)
+
+```js
+<WKWebView source={require('./index.html')} />
+```
+
 - **userAgent="MyUserAgent" (or customUserAgent="...")**
 
 Set a custom user agent for WKWebView. Note this only works on iOS 9+. Previous version will simply ignore this props.

--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -308,12 +308,11 @@ class WKWebView extends React.Component {
       WKWebViewManager.startLoadWithResult(!!shouldStart, event.nativeEvent.lockIdentifier);
     });
 
-    let source = {};
-    if (this.props.source && typeof this.props.source == 'object') {
-      source = Object.assign({}, this.props.source, {
-        sendCookies: this.props.sendCookies,
-        customUserAgent: this.props.customUserAgent || this.props.userAgent
-      });
+    let source = this.props.source || {};
+    if (typeof source == 'object') {
+      source.sendCookies = this.props.sendCookies;
+      source.customUserAgent =
+        this.props.customUserAgent || this.props.userAgent;
     }
 
     if (this.props.html) {


### PR DESCRIPTION
React-native's webview allow html files to be directly required. 

```js
<WKWebView source={require('./index.html')} />
```

The fix is pretty straighforward, `PropTypes` already allow a number as source, managed by React-native internal packager. The only difference come from the initialisation of the [`source` variable](https://github.com/facebook/react-native/blob/master/Libraries/Components/WebView/WebView.ios.js#L467).
For obvious reasons, `sendCookies` and `userAgent` are being ignored.

Fixes #54 