### PR TITLE
Enable traditional window.postMessage() usage even when onMessage prop is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 ios/RCTWKWebView.xcodeproj/xcuserdata/*
 ios/RCTWKWebView.xcodeproj/project.xcworkspace/xcuserdata/*
+macos/RCTWKWebView.xcodeproj/xcuserdata

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -138,7 +138,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)setupPostMessageScript {
   if (_messagingEnabled) {
-    NSString *source=@"window.originalPostMessage = window.postMessage; window.postMessage = function (data) { window.webkit.messageHandlers.reactNative.postMessage(data); }";
+    NSString *source=@"window.originalPostMessage = window.postMessage; window.postMessage = function(message, targetOrigin, transfer) { return typeof targetOrigin === 'undefined' ? window.webkit.messageHandlers.reactNative.postMessage(message) : window.originalPostMessage(message, targetOrigin, transfer); };";
     WKUserScript *script = [[WKUserScript alloc] initWithSource:source
                            injectionTime:WKUserScriptInjectionTimeAtDocumentEnd
                                                forMainFrameOnly:_injectedJavaScriptForMainFrameOnly];


### PR DESCRIPTION
Fixes #170, and perhaps the ambiguous (albeit closed) #128.

Currently, the following code is injected upon the `.atDocumentEnd` hook (yes, it's horrible, but it's consistent with the [horrible behaviour of RN's `<WebView>` component](https://github.com/facebook/react-native/blob/26684cf3adf4094eb6c405d345a75bf8c7c0bf88/React/Views/RCTWebView.m#L313)):

```js
window.originalPostMessage = window.postMessage;
window.postMessage = function() {
    return window.webkit.messageHandlers.reactNative.postMessage.apply(window.webkit.messageHandlers.reactNative, arguments);
};
```

As you can see, we retain a reference to `window.originalPostMessage`.

The `window.postMessage()` [docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) show that it is invoked with two to three parameters:

```
targetWindow.postMessage(message, targetOrigin, [transfer]);
```

RN's `window.postMessage()`, by contrast, specifically accepts only the first param, and incidentally that must be a string (rather than any type that works with the [Structured Clone Algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)).

So we can both maintain consistency with the core *and* un-break `window.postMessage()` for traditional usages:

```js
window.originalPostMessage = window.postMessage;
window.postMessage = function(message, targetOrigin, transfer) {
	return typeof targetOrigin === 'undefined' ? 
		window.webkit.messageHandlers.reactNative.postMessage(message) : 
		window.originalPostMessage(message, targetOrigin, transfer);
};
```