### PR TITLE
Expose title and location of currently displayed document

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -400,6 +400,20 @@ class WKWebView extends React.Component {
   };
 
   /**
+   * Obtain a Promise for the title of the currently displayed document.
+   */
+  title = () => {
+    return WKWebViewManager.title(this.getWebViewHandle());
+  };
+
+  /**
+   * Obtain a Promise for the absolute URL of the currently displayed document.
+   */
+  location = () => {
+    return WKWebViewManager.location(this.getWebViewHandle());
+  };
+
+  /**
    * Reloads the current page.
    */
   reload = () => {

--- a/ios/RCTWKWebView/RCTWKWebView.h
+++ b/ios/RCTWKWebView/RCTWKWebView.h
@@ -44,6 +44,8 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 - (void)goBack;
 - (BOOL)canGoBack;
 - (BOOL)canGoForward;
+- (NSString *)title;
+- (NSString *)location;
 - (void)reload;
 - (void)stopLoading;
 - (void)postMessage:(NSString *)message;

--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -289,6 +289,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   return [_webView canGoForward];
 }
 
+- (NSString *)title {
+  return _webView.title;
+}
+
+- (NSString *)location {
+  return _webView.URL.absoluteString;
+}
+
 - (void)reload
 {
   [_webView reload];

--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -116,6 +116,28 @@ RCT_EXPORT_METHOD(canGoForward:(nonnull NSNumber *)reactTag
   }];
 }
 
+RCT_EXPORT_METHOD(title:(nonnull NSNumber *)reactTag
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWKWebView *> *viewRegistry) {
+    RCTWKWebView *view = viewRegistry[reactTag];
+    
+    resolve([view title]);
+  }];
+}
+
+RCT_EXPORT_METHOD(location:(nonnull NSNumber *)reactTag
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWKWebView *> *viewRegistry) {
+    RCTWKWebView *view = viewRegistry[reactTag];
+    
+    resolve([view location]);
+  }];
+}
+
 RCT_EXPORT_METHOD(reload:(nonnull NSNumber *)reactTag)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWKWebView *> *viewRegistry) {


### PR DESCRIPTION
Exposes title and location properties of the currently displayed document.

Amongst other uses, this would enable a platform agnostic solution to the problem that's trying to be addressed here:

https://github.com/CRAlpha/react-native-wkwebview/pull/151

These properties are not supported by the core RN `WebView` component, and as such, don't comply with the goal of being a drop in replacement for that component.  Importantly, it means that these exposed methods will _not_ work on Android, despite being exposed as if they are platform agnostic in this PR.

This compatibility issue parallels the existing exposure of `canGoBack` and `canGoForward`, though (which presumably also will not function on Android?).  I don't know if the same rationale that allowed those methods to be exposed can be applied here.