### PR TITLE
Add support for UIScrollView.KeyboardDismissMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ This property specifies how the safe area insets are used to modify the content 
 
 Enables focusing an input inside a webview and showing the keyboard *programatically*. **New in 1.20.0**
 
+- **keyboardDismissMode**
+
+Sets the manner in which the keyboard is dismissed when a drag begins in the scroll view. Possible values are "none", "on-drag" and "interactive". Default to "none".
+
 - **injectJavaScript, injectJavaScriptForMainFrameOnly**
 
 Add JavaScript at document start, see [WKUserScriptInjectionTimeAtDocumentStart](https://developer.apple.com/documentation/webkit/wkuserscriptinjectiontime/wkuserscriptinjectiontimeatdocumentstart?language=objc). **New in 1.20.0**

--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -263,6 +263,15 @@ class WKWebView extends React.Component {
      * A Boolean value that sets whether diagonal scrolling is allowed.
     */
     directionalLockEnabled: PropTypes.bool,
+    /*
+     * The manner in which the keyboard is dismissed when a drag begins in the
+     * scroll view.
+     */
+    keyboardDismissMode: PropTypes.oneOf([
+      'none', // Default
+      'on-drag',
+      'interactive', // iOS only
+    ]),
   };
 
   state = {
@@ -359,6 +368,7 @@ class WKWebView extends React.Component {
         pagingEnabled={this.props.pagingEnabled}
         directionalLockEnabled={this.props.directionalLockEnabled}
         onNavigationResponse={this._onNavigationResponse}
+        keyboardDismissMode={this.props.keyboardDismissMode}
       />;
 
     return (

--- a/ios/RCTWKWebView/RCTWKWebViewManager.m
+++ b/ios/RCTWKWebView/RCTWKWebViewManager.m
@@ -21,6 +21,12 @@ RCT_ENUM_CONVERTER(UIScrollViewContentInsetAdjustmentBehavior, (@{
                                                                   }), UIScrollViewContentInsetAdjustmentNever, integerValue)
 #endif
 
+RCT_ENUM_CONVERTER(UIScrollViewKeyboardDismissMode, (@{
+                                                      @"none": @(UIScrollViewKeyboardDismissModeNone),
+                                                      @"on-drag": @(UIScrollViewKeyboardDismissModeOnDrag),
+                                                      @"interactive": @(UIScrollViewKeyboardDismissModeInteractive),
+                                                      }), UIScrollViewKeyboardDismissModeNone, integerValue)
+
 @end
 
 @interface RCTWKWebViewManager () <RCTWKWebViewDelegate>
@@ -46,6 +52,7 @@ RCT_EXPORT_VIEW_PROPERTY(source, NSDictionary)
 RCT_REMAP_VIEW_PROPERTY(bounces, _webView.scrollView.bounces, BOOL)
 RCT_REMAP_VIEW_PROPERTY(pagingEnabled, _webView.scrollView.pagingEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, _webView.scrollView.scrollEnabled, BOOL)
+RCT_REMAP_VIEW_PROPERTY(keyboardDismissMode, _webView.scrollView.keyboardDismissMode, UIScrollViewKeyboardDismissMode)
 RCT_REMAP_VIEW_PROPERTY(directionalLockEnabled, _webView.scrollView.directionalLockEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(allowsBackForwardNavigationGestures, _webView.allowsBackForwardNavigationGestures, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(injectJavaScriptForMainFrameOnly, BOOL)


### PR DESCRIPTION
Add support for inner `ScrollView`'s `KeyboardDismissMode` property. It allows keyboard to be dis-missed by just scrolling the Webview for example.