### PR TITLE
Add onContentProcessDidTerminate event handler

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -192,6 +192,10 @@ class WKWebView extends React.Component {
      */
     onNavigationResponse: PropTypes.func,
     /**
+     * Invoked when the webview content process gets terminated.
+     */
+    onContentProcessDidTerminate: PropTypes.func,
+    /**
      * @platform ios
      */
     bounces: PropTypes.bool,
@@ -368,6 +372,7 @@ class WKWebView extends React.Component {
         pagingEnabled={this.props.pagingEnabled}
         directionalLockEnabled={this.props.directionalLockEnabled}
         onNavigationResponse={this._onNavigationResponse}
+        onContentProcessDidTerminate={this._onContentProcessDidTerminate}
         keyboardDismissMode={this.props.keyboardDismissMode}
       />;
 
@@ -524,6 +529,11 @@ class WKWebView extends React.Component {
   _onNavigationResponse = (event: Event) => {
     const { onNavigationResponse } = this.props;
     onNavigationResponse && onNavigationResponse(event)
+  }
+
+  _onContentProcessDidTerminate = (event: Event) => {
+    const { onContentProcessDidTerminate } = this.props;
+    onContentProcessDidTerminate && onContentProcessDidTerminate(event)
   }
 }
 

--- a/ios/RCTWKWebView/CRAWKWebView.m
+++ b/ios/RCTWKWebView/CRAWKWebView.m
@@ -34,6 +34,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onMessage;
 @property (nonatomic, copy) RCTDirectEventBlock onScroll;
 @property (nonatomic, copy) RCTDirectEventBlock onNavigationResponse;
+@property (nonatomic, copy) RCTDirectEventBlock onContentProcessDidTerminate;
 @property (assign) BOOL sendCookies;
 @property (nonatomic, strong) WKUserScript *atStartScript;
 @property (nonatomic, strong) WKUserScript *atEndScript;
@@ -606,6 +607,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
 {
+  if (_onContentProcessDidTerminate) {
+    NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+    _onContentProcessDidTerminate(event);
+  }
   RCTLogWarn(@"Webview Process Terminated");
 }
 

--- a/ios/RCTWKWebView/CRAWKWebView.m
+++ b/ios/RCTWKWebView/CRAWKWebView.m
@@ -607,11 +607,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
 {
+  RCTLogWarn(@"Webview Process Terminated");
   if (_onContentProcessDidTerminate) {
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     _onContentProcessDidTerminate(event);
   }
-  RCTLogWarn(@"Webview Process Terminated");
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler {

--- a/ios/RCTWKWebView/CRAWKWebViewManager.m
+++ b/ios/RCTWKWebView/CRAWKWebViewManager.m
@@ -77,6 +77,7 @@ RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
 #endif
 RCT_EXPORT_VIEW_PROPERTY(onNavigationResponse, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onContentProcessDidTerminate, RCTDirectEventBlock)
 
 RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)
 {


### PR DESCRIPTION
Hi there!

I had the problem that webviews crashed after running for some time, turning them into blank views. Did some research and invoking a reload on `webViewWebContentProcessDidTerminate` worked for some people. It seems to work fine when testing in the simulator. You can trigger it by killing the `com.apple.WebKit.WebContent` process in Activity Monitor (I loaded a page with an infinite JS while loop to consume a lot of memory to identify the correct one).

I have yet to test if it fully solves my problem as it is harder to reproduce on devices, but being able to handle `webViewWebContentProcessDidTerminate` shouldn't hurt anyways.

(Never done any Objective-C before, ping me if I missed something) 