### PR TITLE
Update keyboardDisplayRequiresUserAction swizzling for 12.2+

### DIFF
--- a/ios/RCTWKWebView/CRAWKWebView.m
+++ b/ios/RCTWKWebView/CRAWKWebView.m
@@ -211,9 +211,19 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   if (!keyboardDisplayRequiresUserAction) {
     Class class = NSClassFromString(@"WKContentView");
+
+    NSOperatingSystemVersion iOS_12_2_0 = (NSOperatingSystemVersion){12, 2, 0};
     NSOperatingSystemVersion iOS_11_3_0 = (NSOperatingSystemVersion){11, 3, 0};
-    
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_11_3_0]) {
+
+    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_12_2_0]) {
+      SEL selector = sel_getUid("_elementDidFocus:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
+      Method method = class_getInstanceMethod(class, selector);
+      IMP original = method_getImplementation(method);
+      IMP override = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, BOOL arg3, id arg4) {
+        ((void (*)(id, SEL, void*, BOOL, BOOL, BOOL, id))original)(me, selector, arg0, TRUE, arg2, arg3, arg4);
+      });
+      method_setImplementation(method, override);
+    } else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion: iOS_11_3_0]) {
       SEL selector = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:changingActivityState:userObject:");
       Method method = class_getInstanceMethod(class, selector);
       IMP original = method_getImplementation(method);


### PR DESCRIPTION
Per [recent posts](https://stackoverflow.com/a/55344531) in the SO thread the original implementation was inspired by, this updates the `keyboardDisplayRequiresUserAction` swizzle for iOS 12.2+